### PR TITLE
Cleartext credentials and DB name removed

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-spring.datasource.url=jdbc:sqlserver://maritimedb.database.windows.net:1433;databaseName=ParticipantDB_BrokerQA
-spring.datasource.username=maritime
-spring.datasource.password=Passw0rd
+spring.datasource.url=<Insert non commercial URL>
+spring.datasource.username= <Insert Username>
+spring.datasource.password=<Insert Password>
 spring.datasource.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
 spring.jpa.show-sql=true
 spring.jpa.hibernate.dialect=org.hibernate.dialect.SQLServer2012Dialect


### PR DESCRIPTION
Having the cleartext credentials and DB name, even though it was a local machine, is flagging on external security breach sites. This impacts the organisations security posture and causes reputational damage. If no longer required remove code completely.